### PR TITLE
Print and diagnostic dump of directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ target/
 /*log
 **/tests/**/*.actual.beancount
 /result
+/debug
 limabean.log*
 .rebel_readline_history

--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 
 - support for running raw plugins, with auto_accounts as an example
+- pass custom meta values through to Clojure
 
 ### Changed
 

--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. This change
 - support for running raw plugins, with auto_accounts as an example
 - pass custom meta values through to Clojure
 - if LIMABEAN_DEBUG_DIR is defined, dump intermediate beanfiles into that directory
+- print method for directives
 
 ### Changed
 

--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. This change
 
 - support for running raw plugins, with auto_accounts as an example
 - pass custom meta values through to Clojure
+- if LIMABEAN_DEBUG_DIR is defined, dump intermediate beanfiles into that directory
 
 ### Changed
 

--- a/clj/doc/30-getting-started.md
+++ b/clj/doc/30-getting-started.md
@@ -143,3 +143,4 @@ Quotes are essential, as what is being passed is Clojure code exactly as it woul
 - `LIMABEAN_LOG` - path to logfile, for troubleshooting
 - `LIMABEAN_POD_LOG` - path to logfile for `limabean-pod` logging including JSON-RPC messages at `DEBUG` level, otherwise no logging
 - `LIMABEAN_POD_LOG_LEVEL` - custom log levels for `limabean-pod` as per `RUST_LOG` conventions, or default log levels if omitted
+- `LIMABEAN_DEBUG_DIR` - if set, is a directory where intermediate beanfiles (post-plugin, pre-booking), are dumped, for troubleshooting

--- a/clj/src/limabean/adapter/debug.clj
+++ b/clj/src/limabean/adapter/debug.clj
@@ -1,0 +1,24 @@
+(ns limabean.adapter.debug
+  (:require [clojure.java.io :as io]
+            [limabean.core.format :as format]))
+
+(def ^{:private true} DEBUG-DIR (System/getenv "LIMABEAN_DEBUG_DIR"))
+
+(defn dump-configured? [] (not (nil? DEBUG-DIR)))
+
+(defn dump
+  "Dump directives in human-readable form into LIMABEAN_DEBUG_DIR if defined"
+  [directives filename]
+  (when DEBUG-DIR
+    (let [debug-file (io/file DEBUG-DIR filename)]
+      (try
+        (with-open [w (io/writer debug-file)]
+          (binding [*out* w]
+            (run! print
+                  (interpose "\n" (map format/directive->str directives)))))
+        (catch Exception e
+          (binding [*out* *err*]
+            (println
+              "WARNING: $LIMABEAN_DEBUG_DIR is defined but failed to write directives to"
+              (.getPath debug-file)
+              (.getMessage e))))))))

--- a/clj/src/limabean/adapter/loader.clj
+++ b/clj/src/limabean/adapter/loader.clj
@@ -2,7 +2,16 @@
   "Load from beanfile and run plugins"
   (:require [limabean.adapter.plugins :as plugins]
             [limabean.adapter.pod :as pod]
-            [limabean.core.registry :as registry]))
+            [limabean.core.registry :as registry]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [limabean.adapter.debug :as debug]))
+
+(defn- dump
+  "Dump the beans and return the map"
+  [m k filename]
+  (debug/dump (get m k) filename)
+  m)
 
 (defn load-beanfile
   [path]
@@ -10,22 +19,31 @@
         plugins (pod/plugins pod)
         options {} ;; TODO get options from JSON-RPC method
         resolved-plugins (plugins/resolve-symbols plugins options)
+        basename (-> (io/file path)
+                     .getName
+                     (str/replace #"\.[^.]*$" ""))
         {:keys [directives warnings]} (pod/directives pod)]
     (cond-> {:pod pod,
              :plugins resolved-plugins,
              :options options,
              :raw-directives directives}
+      (debug/dump-configured?) (dump :raw-directives
+                                     (str basename ".raw.beancount"))
       (seq warnings) (assoc :raw-warnings warnings)
       (plugins/has-specified-plugins? resolved-plugins :raw-xf)
-        (as-> m (let [{:keys [directives errors]} (plugins/run-xf
-                                                    (:raw-directives m)
-                                                    resolved-plugins
-                                                    :raw-xf)]
-                  (cond-> (assoc m :raw-xf-directives directives)
-                    (seq errors) (assoc :raw-xf-errors errors))))
+        (as-> m
+          (let [{:keys [directives errors]}
+                  (plugins/run-xf (:raw-directives m) resolved-plugins :raw-xf)]
+            (cond-> (assoc m :raw-xf-directives directives)
+              (debug/dump-configured?) (dump :raw-xf-directives
+                                             (str basename ".raw-xf.beancount"))
+              (seq errors) (assoc :raw-xf-errors errors))))
       true (as-> m (let [{:keys [directives warnings]}
                            (pod/book pod (:raw-xf-directives m))]
                      (cond-> (assoc m :booked-directives directives)
+                       (debug/dump-configured?) (dump :booked-directives
+                                                      (str basename
+                                                           ".booked.beancount"))
                        (seq warnings) (assoc :booked-warnings warnings))))
       (plugins/has-specified-plugins? resolved-plugins :booked-xf)
         (as-> m (let [{:keys [directives errors]} (plugins/run-xf
@@ -33,6 +51,9 @@
                                                     resolved-plugins
                                                     :booked-xf)]
                   (cond-> (assoc m :booked-xf-directives directives)
+                    (debug/dump-configured?) (dump :booked-xf-directives
+                                                   (str basename
+                                                        ".booked-xf.beancount"))
                     (seq errors) (assoc :booked-xf-errors errors))))
       true (as-> m (assoc m
                      :directives (or (:booked-xf-directives m)

--- a/clj/src/limabean/adapter/loader.clj
+++ b/clj/src/limabean/adapter/loader.clj
@@ -13,6 +13,17 @@
   (debug/dump (get m k) filename)
   m)
 
+(defn- typed
+  "Return a function which applies metadata if required to ensure `x` is typed as `kind`"
+  [kind]
+  (fn [x] (if (= (:type (meta x)) kind) x (with-meta x {:type kind}))))
+
+(defn- typed-directives
+  "Apply metadata to all directives"
+  [directives]
+  ((typed :limabean/directives)
+    (into [] (map (typed :limabean/dct) directives))))
+
 (defn load-beanfile
   [path]
   (let [pod (pod/start path)
@@ -26,7 +37,7 @@
     (cond-> {:pod pod,
              :plugins resolved-plugins,
              :options options,
-             :raw-directives directives}
+             :raw-directives (typed-directives directives)}
       (debug/dump-configured?) (dump :raw-directives
                                      (str basename ".raw.beancount"))
       (seq warnings) (assoc :raw-warnings warnings)
@@ -34,13 +45,14 @@
         (as-> m
           (let [{:keys [directives errors]}
                   (plugins/run-xf (:raw-directives m) resolved-plugins :raw-xf)]
-            (cond-> (assoc m :raw-xf-directives directives)
+            (cond-> (assoc m :raw-xf-directives (typed-directives directives))
               (debug/dump-configured?) (dump :raw-xf-directives
                                              (str basename ".raw-xf.beancount"))
               (seq errors) (assoc :raw-xf-errors errors))))
       true (as-> m (let [{:keys [directives warnings]}
                            (pod/book pod (:raw-xf-directives m))]
-                     (cond-> (assoc m :booked-directives directives)
+                     (cond-> (assoc m
+                               :booked-directives (typed-directives directives))
                        (debug/dump-configured?) (dump :booked-directives
                                                       (str basename
                                                            ".booked.beancount"))
@@ -50,7 +62,8 @@
                                                     (:booked-directives m)
                                                     resolved-plugins
                                                     :booked-xf)]
-                  (cond-> (assoc m :booked-xf-directives directives)
+                  (cond-> (assoc m
+                            :booked-xf-directives (typed-directives directives))
                     (debug/dump-configured?) (dump :booked-xf-directives
                                                    (str basename
                                                         ".booked-xf.beancount"))

--- a/clj/src/limabean/adapter/print.clj
+++ b/clj/src/limabean/adapter/print.clj
@@ -1,6 +1,16 @@
-(ns limabean.adapter.print)
+(ns limabean.adapter.print
+  (:require [limabean.core.format :as format]))
 
 ;; make printing LocalDate use the same form
 (defmethod print-method java.time.LocalDate
   [v w]
   (.write w (str "#time/date \"" v "\"")))
+
+(defmethod print-method :limabean/dct
+  [dct writer]
+  (doto writer (.write (format/directive->str dct))))
+
+(defmethod print-method :limabean/directives
+  [directives writer]
+  (run! #(.write writer %)
+        (interpose "\n" (map format/directive->str directives))))

--- a/clj/src/limabean/core/format.clj
+++ b/clj/src/limabean/core/format.clj
@@ -3,7 +3,7 @@
 
 (defn- dct-type
   [dct]
-  (let [type (:dct dct)] (if (= type :txn) (:flag dct) (name type))))
+  (let [type (:dct dct)] (if (= type :txn) (or (:flag dct) "txn") (name type))))
 
 (defn- double-quote
   "Double quote a string, otherwise nil"

--- a/clj/src/limabean/core/format.clj
+++ b/clj/src/limabean/core/format.clj
@@ -54,6 +54,32 @@
                        (if v " " "")
                        (meta-value->str v))))))
 
+(defn- cost->str
+  "Convert cost or cost-spec to string"
+  [cost]
+  (let [bare-cost-str
+          (with-out-str
+            ;; print at most one of per-unit and total, preferring per-unit
+            (if-let [per-unit (:per-unit cost)]
+              (print (str per-unit))
+              (when-let [total (:total cost)] (print "#" (str total))))
+            (when-let [cur (:cur cost)] (print "" cur))
+            (when-let [date (:date cost)] (print "," (str date)))
+            (when-let [label (double-quote (:label cost))] (print "," label))
+            (when (:merge cost) (print ", *")))]
+    (str "{" (str/replace-first bare-cost-str #"^,? " "") "}")))
+
+(defn- price->str
+  "Convert price or price-spec to string"
+  [price]
+  (with-out-str (print "@")
+                ;; print at most one of per-unit and total, preferring
+                ;; per-unit
+                (if-let [per-unit (:per-unit price)]
+                  (print "" (str per-unit))
+                  (when-let [total (:total price)] (print " #" (str total))))
+                (when-let [cur (:cur price)] (print "" cur))))
+
 (defn directive->str
   "Convert directive to string"
   [dct]
@@ -102,9 +128,13 @@
         (print "" (:acc posting))
         (when-let [units (:units posting)] (print "" (str units)))
         (when-let [cur (:cur posting)] (print "" cur))
-        ;; TODO cost/cost-spec
-        ;; TODO price/price-spec
-        (print-tags-and-links-inline (:tags posting) (:links posting))
+        (when-let [cost (or (:cost posting) (:cost-spec posting))]
+          (print "" (cost->str cost)))
+        (when-let [price (or (:price posting) (:price-spec posting))]
+          (print "" (price->str price)))
         (println)
+        (print-tags-and-links-on-separate-lines "  "
+                                                (:tags posting)
+                                                (:links posting))
         (when-let [metadata (:metadata posting)]
           (print-meta-key-values-on-separate-lines "  " metadata))))))

--- a/clj/src/limabean/core/format.clj
+++ b/clj/src/limabean/core/format.clj
@@ -1,0 +1,110 @@
+(ns limabean.core.format
+  (:require [clojure.string :as str]))
+
+(defn- dct-type
+  [dct]
+  (let [type (:dct dct)] (if (= type :txn) (:flag dct) (name type))))
+
+(defn- double-quote
+  "Double quote a string, otherwise nil"
+  [s]
+  (and (string? s) (format "\"%s\"" s)))
+
+(defn- prefix
+  "Prefix a string, otherwise nil"
+  [s prefix]
+  (and (string? s) (format "%s%s" prefix s)))
+
+(defn- booking->str
+  [booking]
+  (and (keyword? booking)
+       (double-quote (str/replace (str/upper-case (name booking)) "-" "_"))))
+
+(defn- print-tags-and-links-inline
+  [tags links]
+  (when tags (doseq [tag tags] (print "" (prefix tag "#"))))
+  (when links (doseq [link links] (print "" (prefix link "^")))))
+
+(defn- print-tags-and-links-on-separate-lines
+  [indent tags links]
+  (when tags (doseq [tag tags] (println (str indent (prefix tag "#")))))
+  (when links (doseq [link links] (println (str indent (prefix link "^"))))))
+
+(defn- meta-value->str
+  [v]
+  (cond (nil? v) ""
+        (contains? v :acc) (get v :acc)
+        (and (contains? v :units) (contains? v :cur))
+          (format "%s %s" (str (get v :units)) (get v :cur))
+        (contains? v :string) (double-quote (get v :string))
+        (contains? v :bool) (str/upper-case (str (get v :bool)))
+        (contains? v :cur) (get v :cur)
+        (contains? v :number) (str (get v :number))
+        (contains? v :tag) (prefix (get v :tag) "#")
+        (contains? v :link) (prefix (get v :link) "^")
+        (contains? v :date) (str (get v :date))))
+
+(defn- print-meta-key-values-on-separate-lines
+  [indent meta-key-values]
+  (doseq [k (sort (keys meta-key-values))]
+    (let [v (get meta-key-values k)]
+      (println (format "%s%s:%s%s"
+                       indent
+                       (name k)
+                       (if v " " "")
+                       (meta-value->str v))))))
+
+(defn directive->str
+  "Convert directive to string"
+  [dct]
+  (with-out-str
+    (print (str (:date dct)) (dct-type dct))
+    (case (:dct dct)
+      :txn (let [payee (double-quote (:payee dct))
+                 narration (double-quote (:narration dct))
+                 empty (double-quote "")]
+             (cond (and payee narration) (print "" payee narration)
+                   payee (print "" payee empty)
+                   narration (print "" narration)))
+      :price (let [price (:price dct)]
+               (print "" (:cur dct) (str (:per-unit price)) (:cur price)))
+      :balance (do (print "" (:acc dct) (str (:units dct)) (:cur dct))
+                   (when-let [tol (:tolerance dct)] (print " ~" (str tol))))
+      :open (do (print "" (:acc dct))
+                (when-let [currencies (:currencies dct)]
+                  (print "" (str/join "," (sort currencies))))
+                (when-let [booking (booking->str (:booking dct))]
+                  (print "" booking)))
+      :close (print "" (:acc dct))
+      :commodity (print "" (:cur dct))
+      :pad (print "" (:acc dct) (:source dct))
+      :document (print "" (:acc dct) (double-quote (:path dct)))
+      :note (print "" (:acc dct) (double-quote (:comment dct)))
+      :event
+        (print "" (double-quote (:type dct)) (double-quote (:description dct)))
+      :query (print "" (double-quote (:name dct)) (double-quote (:content dct)))
+      :custom (do (print "" (double-quote (:type dct)))
+                  (doseq [v (:values dct)] (print "" (meta-value->str v))))
+      nil)
+    (when-not (= (:dct dct) :custom)
+      (print-tags-and-links-inline (:tags dct) (:links dct)))
+    (println)
+    (when (= (:dct dct) :custom)
+      ;; print tags/links for custom on separate lines to avoid confusion
+      ;; with meta values
+      (print-tags-and-links-on-separate-lines "  " (:tags dct) (:links dct)))
+    (when-let [metadata (:metadata dct)]
+      (print-meta-key-values-on-separate-lines "  " metadata))
+    (when (= (:dct dct) :txn)
+      (doseq [posting (:postings dct)]
+        (print " ")
+        (when-let [flag (:flag posting)] (print "" flag))
+        (print "" (:acc posting))
+        (when-let [units (:units posting)] (print "" (str units)))
+        (when-let [cur (:cur posting)] (print "" cur))
+        ;; TODO cost/cost-spec
+        ;; TODO price/price-spec
+        (print-tags-and-links-inline (:tags posting) (:links posting))
+        (println)
+        (when-let [metadata (:metadata posting)]
+          (print-meta-key-values-on-separate-lines "  " metadata))))))

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
               export LIMABEAN_BEANFILE="$(pwd)/test-cases/full.beancount"
               export LIMABEAN_LOG="$(pwd)/limabean.log"
               export LIMABEAN_POD_LOG="$(pwd)/limabean-pod.log"
+              export LIMABEAN_DEBUG_DIR="$(pwd)/debug"
             '';
           };
 

--- a/rust/src/api/types/parser_type_conversions.rs
+++ b/rust/src/api/types/parser_type_conversions.rs
@@ -159,22 +159,22 @@ impl<'a> From<&'_ parser::Custom<'a>> for Custom<'a> {
     fn from(value: &'_ parser::Custom<'a>) -> Self {
         Custom {
             type_: Cow::Borrowed(value.type_().item()),
-            // TODO custom meta values
+            values: value.values().map(|v| v.item().into()).collect::<Vec<_>>(),
         }
     }
 }
 
 pub(crate) fn from_flag(flag: parser::Flag) -> Cow<'static, str> {
-    use beancount_parser_lima::Flag::*;
+    use beancount_parser_lima::Flag;
 
     match flag {
-        Asterisk => Cow::Borrowed("*"),
-        Exclamation => Cow::Borrowed("!"),
-        Ampersand => Cow::Borrowed("&"),
-        Hash => Cow::Borrowed("#"),
-        Question => Cow::Borrowed("?"),
-        Percent => Cow::Borrowed("%"),
-        Letter(_) => Cow::Owned(flag.to_string()),
+        Flag::Asterisk => Cow::Borrowed("*"),
+        Flag::Exclamation => Cow::Borrowed("!"),
+        Flag::Ampersand => Cow::Borrowed("&"),
+        Flag::Hash => Cow::Borrowed("#"),
+        Flag::Question => Cow::Borrowed("?"),
+        Flag::Percent => Cow::Borrowed("%"),
+        Flag::Letter(_) => Cow::Owned(flag.to_string()),
     }
 }
 
@@ -210,36 +210,36 @@ impl<'a> From<&'_ parser::CostSpec<'a>> for CostSpec<'a> {
 
 impl<'a> From<&'_ parser::PriceSpec<'a>> for PriceSpec<'a> {
     fn from(value: &'_ parser::PriceSpec<'a>) -> Self {
-        use beancount_parser_lima::PriceSpec::*;
+        use beancount_parser_lima::PriceSpec as PPS;
         use beancount_parser_lima::ScopedExprValue::*;
 
         match value {
-            Unspecified => PriceSpec {
+            PPS::Unspecified => PriceSpec {
                 per_unit: None,
                 total: None,
                 cur: None,
             },
-            BareCurrency(cur) => PriceSpec {
+            PPS::BareCurrency(cur) => PriceSpec {
                 per_unit: None,
                 total: None,
                 cur: Some(cur.into()),
             },
-            BareAmount(PerUnit(expr)) => PriceSpec {
+            PPS::BareAmount(PerUnit(expr)) => PriceSpec {
                 per_unit: Some(expr.value()),
                 total: None,
                 cur: None,
             },
-            BareAmount(Total(expr)) => PriceSpec {
+            PPS::BareAmount(Total(expr)) => PriceSpec {
                 per_unit: None,
                 total: Some(expr.value()),
                 cur: None,
             },
-            CurrencyAmount(PerUnit(expr), cur) => PriceSpec {
+            PPS::CurrencyAmount(PerUnit(expr), cur) => PriceSpec {
                 per_unit: Some(expr.value()),
                 total: None,
                 cur: Some(cur.into()),
             },
-            CurrencyAmount(Total(expr), cur) => PriceSpec {
+            PPS::CurrencyAmount(Total(expr), cur) => PriceSpec {
                 per_unit: None,
                 total: Some(expr.value()),
                 cur: Some(cur.into()),

--- a/rust/src/api/types/raw.rs
+++ b/rust/src/api/types/raw.rs
@@ -152,8 +152,10 @@ pub struct Query<'a> {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Custom<'a> {
+    #[serde(rename = "type")]
     pub(crate) type_: Cow<'a, str>,
-    // TODO custom meta values
+    #[serde(borrow)]
+    pub(crate) values: Vec<MetaValue<'a>>,
 }
 
 /// A potentially incomplete posting-specification.

--- a/test-cases/full.beancount
+++ b/test-cases/full.beancount
@@ -141,5 +141,10 @@ popmeta drink:
   Assets:US:ETrade:Cash
   Expenses:Financial:Commissions                            9.95 USD
 
-2028-01-01 query "fictional SQL" "SELECT money FROM accounts;" #for-testing
+2025-01-01 query "fictional SQL" "SELECT money FROM accounts;" #for-testing
   status: "bogus"
+
+2025-02-10 custom "all the things!" 10.50 USD "anticipation" CAD Expenses:Groceries #my-custom-tag ^my-custom-link 2023-06-01 TRUE 150
+  i-am-meta: "yay!"
+  #i-am-a-meta-tag
+  ^i-am-a-meta-link


### PR DESCRIPTION
Dump intermediate beanfiles into LIMABEAN_DEBUG_DIR if defined.

Add print method for directives.