### PR TITLE
Map underscore to hyphen before resolving plugin namespace

### DIFF
--- a/clj/doc/40-plugins.md
+++ b/clj/doc/40-plugins.md
@@ -58,7 +58,7 @@ A limabean plugin namespace is simply a [Clojure namespace](https://guide.clojur
 
 The intention is that `limabean.contrib.plugins` is a place for development and refinement of plugins, which upon gaining stability may be promoted into the `limabean.plugins` itself.
 
-Legacy plugins appear with their original names, e.g. `beancount.plugins.auto_accounts`.
+Legacy plugins appear with their original names, e.g. `beancount.plugins.auto-accounts`.  Because Clojure prefers hyphen to underscore in namespace names, any plugin name from a Beancount file containing underscores gets changed to hyphens before resolving as a Clojure namespace.  Therefore, such plugins may continue to be referenced by their original names from Beancount files.
 
 ### Errors
 

--- a/clj/src/beancount/plugins/auto_accounts.clj
+++ b/clj/src/beancount/plugins/auto_accounts.clj
@@ -1,4 +1,4 @@
-(ns beancount.plugins.auto_accounts
+(ns beancount.plugins.auto-accounts
   (:require [clojure.set :as set]))
 
 (defn raw-xf

--- a/clj/src/limabean/adapter/plugins.clj
+++ b/clj/src/limabean/adapter/plugins.clj
@@ -1,10 +1,11 @@
 (ns limabean.adapter.plugins
-  (:require [clojure.edn :as edn]))
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]))
 
 (defn- resolve-xfs
   "Resolve a plugin by loading it from its namespace"
   [name]
-  (let [ns-sym (symbol name)]
+  (let [ns-sym (symbol (str/replace name #"_" "-"))]
     (try (require ns-sym)
          (let [booked-xf-fn (ns-resolve ns-sym 'booked-xf)
                raw-xf-fn (ns-resolve ns-sym 'raw-xf)


### PR DESCRIPTION
This keeps underscores working in Beancount file plugin names, but allows all Clojure namespaces for plugins to use hyphens.