### PR TITLE
Remove nrepl middleware from deps.edn

### DIFF
--- a/clj-test/deps.edn
+++ b/clj-test/deps.edn
@@ -3,10 +3,7 @@
                    io.github.clojure/tools.build {:mvn/version "0.10.12"},
                    slipset/deps-deploy {:mvn/version "0.2.1"}},
             :ns-default build},
-    :cider/nrepl {:extra-deps {cider/cider-nrepl {:mvn/version "0.58.0"},
-                               refactor-nrepl/refactor-nrepl {:mvn/version
-                                                                "3.11.0"}},
-                  :extra-paths ["test" "test-plugins/src"],
+    :cider/nrepl {:extra-paths ["test" "test-plugins/src"],
                   :jvm-opts ["-Djdk.attach.allowAttachSelf"]},
     :dev {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.12"},
                        slipset/deps-deploy {:mvn/version "0.2.1"}},

--- a/clj/deps.edn
+++ b/clj/deps.edn
@@ -5,10 +5,8 @@
                    slipset/deps-deploy {:mvn/version "0.2.1"}},
             :ns-default build},
     :cider/nrepl {:extra-deps
-                    {cider/cider-nrepl {:mvn/version "0.58.0"},
-                     com.health-samurai/matcho {:mvn/version "0.3.11"},
+                    {com.health-samurai/matcho {:mvn/version "0.3.11"},
                      org.clojure/test.check {:mvn/version "1.1.1"},
-                     refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"},
                      zprint/zprint {:mvn/version "1.3.0"}},
                   :extra-paths ["test" "test-plugins/src"],
                   :jvm-opts ["-Djdk.attach.allowAttachSelf"]},


### PR DESCRIPTION
CIDER injects this automatically at jack-in time.