### PR TITLE
Add Containerfile for podman/docker

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -151,3 +151,37 @@ jobs:
           clojure -J--enable-native-access=ALL-UNNAMED -Sdeps "{:mvn/local-repo \"$(pwd)/target/m2\" :deps {io.github.tesujimath/limabean {:mvn/version \"$VERSION\"}}}" -M -m limabean.main --version >VERSION
           cat VERSION
           test "$(cat VERSION)" == "limabean.clj $VERSION"
+
+  check-containerfile:
+    name: Check Containerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set version variable
+        run: echo "VERSION=$(bash ./scripts.dev/get-version.sh)" >> $GITHUB_ENV
+
+      - name: Build image
+        run: |
+          podman build -f Containerfile --build-arg VERSION=$VERSION -t limabean:$VERSION
+
+      - name: Test uberjar using limabean container
+        run: |
+          ID=$(podman run --rm --detach -v .:/data --entrypoint sleep --stop-signal SIGKILL limabean:$VERSION infinity)
+
+          stop() {
+            test -n "$ID" && podman stop "$ID"
+          }
+          trap stop EXIT TERM INT
+
+          for golden in test-cases/simple.golden/{inventory,journal,rollup}; do
+             query=${golden##*/}
+             beanfile=${golden%.golden/$query}.beancount
+             # rollup is no longer a stand-alone query, must be applied to an inventory
+             if test "$query" == rollup; then
+               query="rollup (inventory)"
+             fi
+             echo "Validating $golden"
+             podman exec "$ID" limabean -v --beanfile "$beanfile" --eval "(show ($query))" | diff - $golden
+          done

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,37 @@
+# Builder stage
+FROM docker.io/clojure:tools-deps AS builder
+
+RUN apt-get update && apt-get install -y curl build-essential && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . $HOME/.cargo/env && rustup install stable && rustup default stable
+
+ENV PATH="/root/.cargo/bin:$PATH"
+
+WORKDIR /app
+COPY . .
+
+ARG VERSION
+ENV LIMABEAN_UBERJAR=/app/limabean-${VERSION}-standalone.jar
+
+WORKDIR /app/rust
+RUN cargo build --release
+
+WORKDIR /app/clj
+RUN clojure -T:build uber
+
+# Runtime stage
+FROM docker.io/clojure:tools-deps
+
+ENV PATH="/app/bin:$PATH"
+ENV LIMABEAN_BEANFILE=accounting.beancount
+
+WORKDIR /app
+
+COPY --from=builder /app/rust/target/release/limabean bin/
+COPY --from=builder /app/rust/target/release/limabean-pod bin/
+COPY --from=builder /app/clj/target/limabean-*-standalone.jar .
+
+VOLUME /data
+WORKDIR /data
+
+ENTRYPOINT ["limabean"]

--- a/clj/doc/20-installation.md
+++ b/clj/doc/20-installation.md
@@ -31,6 +31,21 @@ Selection of runtime is determined by the following:
 
 Running from Clojars is recommended for anyone using the [GitHub release](https://github.com/tesujimath/limabean/releases), that is, not setting any of the environment variables listed above.
 
+## Running from Podman
+
+If you have Podman (or Docker) installed, you can build a local container to run limabean in standalone mode:
+
+```
+VERSION=$(bash ./scripts.dev/get-version.sh)
+podman build -f Containerfile --build-arg VERSION=$VERSION -t limabean:$VERSION
+```
+
+Then run it, mounting the directory where the beancount files are as `/data`:
+
+```
+podman run -it --rm --name limabean -v .:/data limabean:$VERSION --beanfile accounting.beancount
+```
+
 ## Running from Clojars
 
 Requirements:


### PR DESCRIPTION
This Containerfile handles building and running `limabean` via podman/docker:

Build:

```bash
VERSION=$(./scripts.dev/get-version.sh) podman build -f Containerfile \
  --build-arg VERSION=$VERSION -t limabean:$VERSION
```

And then it can be run from the directory where the beancount files are:

```bash
podman run -it --rm --name limabean:0.5.0 -v .:/data limabean
```

or it can be aliased:
```bash
alias limabean "podman run -it --rm --name limabean -v .:/data limabean"
limabean --beanfile test.beancount
```

the default `LIMABEAN_BEANFILE`  is `accounting.beancount` but it can be set on the command line as above or the environment variable can be set in the podman command. 