### PR TITLE
Bump parser and booking crates for latest fixes

### DIFF
--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed
+
+- sort Open directives before transactions - beancount-parser-lima#66
+- {} lot reduction - limabean-booking#10
+- correct error returned when prior posting depletes inventory limabean-booking#12
+- tolerance for balance directives #103
+
+### Added
+- Containerfile for podman/docker #94
+
 [commit log]: https://github.com/tesujimath/limabean/compare/0.5.1...HEAD
 
 ## [0.5.1] - 2026-05-05

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -117,9 +117,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "beancount-parser-lima"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7842de7510ff4addab5a5d8262ebc4783f29d7ef3494f78834a28f4987e2ef8b"
+checksum = "cafe4d4726917594c1d14a6371b83d886f59a9fb4f6e70cb600b5c0bcaada5d3"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "limabean-booking"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642fa8586807413bfb9b832b120d5bb6366074bf12ab3c281f9f1bf07a7d6269"
+checksum = "883f674d60837f4702f517d1d87be136f0052648f43e05cb417508ee5fd7c889"
 dependencies = [
  "beancount-parser-lima",
  "hashbrown 0.15.5",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,16 +17,16 @@ name = "limabean-pod"
 path = "src/bin/limabean-pod/main.rs"
 
 [dependencies]
-limabean-booking = { version = "0.10.3", features = [
+limabean-booking = { version = "0.10.4", features = [
   "lima-parser-types",
   "rust-decimal",
 ] }
-# limabean-booking = { path = "../../limabean-booking", version = "0.10.3", features = [
+# limabean-booking = { path = "../../limabean-booking", version = "0.10.4", features = [
 #   "lima-parser-types",
 #   "rust-decimal",
 # ] }
-beancount-parser-lima = "0.16.2"
-# beancount-parser-lima = { version = "0.16.2", path = "../../beancount-parser-lima" }
+beancount-parser-lima = "0.16.3"
+# beancount-parser-lima = { version = "0.16.3", path = "../../beancount-parser-lima" }
 tabulator = { version = "0.6.0", features = [
   "bin",
   "num-bigint",

--- a/test-cases/trading.golden/directives.edn
+++ b/test-cases/trading.golden/directives.edn
@@ -1,0 +1,109 @@
+[{:cur "USD", :date #time/date "1970-01-01", :dct :commodity}
+ {:cur "AAPL", :date #time/date "1970-01-01", :dct :commodity}
+ {:acc "Assets:US:ETrade:Cash", :date #time/date "2010-03-01", :dct :open}
+ {:acc "Assets:US:ETrade:IBM", :date #time/date "2010-03-01", :dct :open}
+ {:acc "Expenses:Financial:Commissions",
+  :date #time/date "2010-03-01",
+  :dct :open}
+ {:acc "Income:US:ETrade:PnL", :date #time/date "2010-03-01", :dct :open}
+ {:date #time/date "2014-02-16",
+  :dct :txn,
+  :flag "*",
+  :narration "Buying some IBM",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-02-16",
+                     :per-unit 160.00M,
+                     :total 1600.00M},
+              :cur "IBM",
+              :units 10}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units -1609.95M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}]}
+ {:date #time/date "2014-02-17",
+  :dct :txn,
+  :flag "*",
+  :narration "Selling some IBM",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-02-16",
+                     :per-unit 160.00M,
+                     :total 1600.00M},
+              :cur "IBM",
+              :units -3}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units 500.05M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}
+             {:acc "Income:US:ETrade:PnL", :cur "USD", :units -30.00M}]}
+ {:date #time/date "2014-02-18",
+  :dct :txn,
+  :flag "*",
+  :narration "I put my chips on big blue!",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-02-18",
+                     :per-unit 180.00M,
+                     :total 900.00M},
+              :cur "IBM",
+              :units 5}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units -909.95M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}]}
+ {:date #time/date "2014-03-18",
+  :dct :txn,
+  :flag "*",
+  :narration "Selling all my blue chips.",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-02-16",
+                     :per-unit 160.00M,
+                     :total 1600.00M},
+              :cur "IBM",
+              :units -7}
+             {:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-02-18",
+                     :per-unit 180.00M,
+                     :total 900.00M},
+              :cur "IBM",
+              :units -5}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units 2054.05M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}
+             {:acc "Income:US:ETrade:PnL", :cur "USD", :units -44.00M}]}
+ {:date #time/date "2014-04-16",
+  :dct :txn,
+  :flag "*",
+  :narration "Buying some more IBM",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-04-16",
+                     :per-unit 173.00M,
+                     :total 1730.00M},
+              :cur "IBM",
+              :units 10}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units -1739.95M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}]}
+ {:date #time/date "2014-04-26",
+  :dct :txn,
+  :flag "*",
+  :narration "Buying IBM yet again",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-04-26",
+                     :per-unit 180.00M,
+                     :total 1800.00M},
+              :cur "IBM",
+              :units 10}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units -1809.95M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}]}
+ {:date #time/date "2014-05-01",
+  :dct :txn,
+  :flag "*",
+  :narration "Selling some older blue chips.",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2014-04-16",
+                     :per-unit 173.00M,
+                     :total 1730.00M},
+              :cur "IBM",
+              :units -4}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units 740.00M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}
+             {:acc "Income:US:ETrade:PnL", :cur "USD", :units -57.95M}]}]

--- a/test-cases/trading.golden/directives.fyi.beancount
+++ b/test-cases/trading.golden/directives.fyi.beancount
@@ -1,0 +1,50 @@
+1970-01-01 commodity USD
+
+1970-01-01 commodity AAPL
+
+2010-03-01 open Assets:US:ETrade:Cash
+
+2010-03-01 open Assets:US:ETrade:IBM
+
+2010-03-01 open Expenses:Financial:Commissions
+
+2010-03-01 open Income:US:ETrade:PnL
+
+2014-02-16 * "Buying some IBM"
+  Assets:US:ETrade:IBM 10 IBM {160.00 USD, 2014-02-16}
+  Assets:US:ETrade:Cash -1609.95 USD
+  Expenses:Financial:Commissions 9.95 USD
+
+2014-02-17 * "Selling some IBM"
+  Assets:US:ETrade:IBM -3 IBM {160.00 USD, 2014-02-16}
+  Assets:US:ETrade:Cash 500.05 USD
+  Expenses:Financial:Commissions 9.95 USD
+  Income:US:ETrade:PnL -30.00 USD
+
+2014-02-18 * "I put my chips on big blue!"
+  Assets:US:ETrade:IBM 5 IBM {180.00 USD, 2014-02-18}
+  Assets:US:ETrade:Cash -909.95 USD
+  Expenses:Financial:Commissions 9.95 USD
+
+2014-03-18 * "Selling all my blue chips."
+  Assets:US:ETrade:IBM -7 IBM {160.00 USD, 2014-02-16}
+  Assets:US:ETrade:IBM -5 IBM {180.00 USD, 2014-02-18}
+  Assets:US:ETrade:Cash 2054.05 USD
+  Expenses:Financial:Commissions 9.95 USD
+  Income:US:ETrade:PnL -44.00 USD
+
+2014-04-16 * "Buying some more IBM"
+  Assets:US:ETrade:IBM 10 IBM {173.00 USD, 2014-04-16}
+  Assets:US:ETrade:Cash -1739.95 USD
+  Expenses:Financial:Commissions 9.95 USD
+
+2014-04-26 * "Buying IBM yet again"
+  Assets:US:ETrade:IBM 10 IBM {180.00 USD, 2014-04-26}
+  Assets:US:ETrade:Cash -1809.95 USD
+  Expenses:Financial:Commissions 9.95 USD
+
+2014-05-01 * "Selling some older blue chips."
+  Assets:US:ETrade:IBM -4 IBM {173.00 USD, 2014-04-16}
+  Assets:US:ETrade:Cash 740.00 USD
+  Expenses:Financial:Commissions 9.95 USD
+  Income:US:ETrade:PnL -57.95 USD

--- a/test-cases/trading.golden/inventory
+++ b/test-cases/trading.golden/inventory
@@ -2,4 +2,4 @@ Assets:US:ETrade:Cash           -2775.70 USD
 Assets:US:ETrade:IBM                6    IBM  2014-04-16 USD 173.00  
                                    10    IBM  2014-04-26 USD 180.00  
 Expenses:Financial:Commissions     69.65 USD                         
-Income:US:ETrade:PnL            -3304.95 USD                         
+Income:US:ETrade:PnL             -131.95 USD                         

--- a/test-cases/trading.golden/journal
+++ b/test-cases/trading.golden/journal
@@ -9,37 +9,36 @@
                                                                                                -1099.95 USD
 2014-02-17  Expenses:Financial:Commissions    Selling some IBM                      9.95  USD      7    IBM
                                                                                                -1090.00 USD
-2014-02-17  Income:US:ETrade:PnL              Selling some IBM                   -507.00  USD      7    IBM
-                                                                                               -1597.00 USD
+2014-02-17  Income:US:ETrade:PnL              Selling some IBM                    -30.00  USD      7    IBM
+                                                                                               -1120.00 USD
 2014-02-18  Assets:US:ETrade:IBM              I put my chips on big blue!           5     IBM     12    IBM
-                                                                                               -1597.00 USD
+                                                                                               -1120.00 USD
 2014-02-18  Assets:US:ETrade:Cash             I put my chips on big blue!        -909.95  USD     12    IBM
-                                                                                               -2506.95 USD
+                                                                                               -2029.95 USD
 2014-02-18  Expenses:Financial:Commissions    I put my chips on big blue!           9.95  USD     12    IBM
-                                                                                               -2497.00 USD
+                                                                                               -2020.00 USD
 2014-03-18  Assets:US:ETrade:IBM              Selling all my blue chips.           -7     IBM      5    IBM
-                                                                                               -2497.00 USD
-2014-03-18  Assets:US:ETrade:IBM              Selling all my blue chips.           -5     IBM  -2497.00 USD
-2014-03-18  Assets:US:ETrade:Cash             Selling all my blue chips.         2054.05  USD   -442.95 USD
-2014-03-18  Expenses:Financial:Commissions    Selling all my blue chips.            9.95  USD   -433.00 USD
-2014-03-18  Income:US:ETrade:PnL              Selling all my blue chips.        -2052.00  USD  -2485.00 USD
+                                                                                               -2020.00 USD
+2014-03-18  Assets:US:ETrade:IBM              Selling all my blue chips.           -5     IBM  -2020.00 USD
+2014-03-18  Assets:US:ETrade:Cash             Selling all my blue chips.         2054.05  USD     34.05 USD
+2014-03-18  Expenses:Financial:Commissions    Selling all my blue chips.            9.95  USD     44.00 USD
+2014-03-18  Income:US:ETrade:PnL              Selling all my blue chips.          -44.00  USD              
 2014-04-16  Assets:US:ETrade:IBM              Buying some more IBM                 10     IBM     10    IBM
-                                                                                               -2485.00 USD
 2014-04-16  Assets:US:ETrade:Cash             Buying some more IBM              -1739.95  USD     10    IBM
-                                                                                               -4224.95 USD
+                                                                                               -1739.95 USD
 2014-04-16  Expenses:Financial:Commissions    Buying some more IBM                  9.95  USD     10    IBM
-                                                                                               -4215.00 USD
+                                                                                               -1730.00 USD
 2014-04-26  Assets:US:ETrade:IBM              Buying IBM yet again                 10     IBM     20    IBM
-                                                                                               -4215.00 USD
+                                                                                               -1730.00 USD
 2014-04-26  Assets:US:ETrade:Cash             Buying IBM yet again              -1809.95  USD     20    IBM
-                                                                                               -6024.95 USD
+                                                                                               -3539.95 USD
 2014-04-26  Expenses:Financial:Commissions    Buying IBM yet again                  9.95  USD     20    IBM
-                                                                                               -6015.00 USD
+                                                                                               -3530.00 USD
 2014-05-01  Assets:US:ETrade:IBM              Selling some older blue chips.       -4     IBM     16    IBM
-                                                                                               -6015.00 USD
+                                                                                               -3530.00 USD
 2014-05-01  Assets:US:ETrade:Cash             Selling some older blue chips.      740.00  USD     16    IBM
-                                                                                               -5275.00 USD
+                                                                                               -2790.00 USD
 2014-05-01  Expenses:Financial:Commissions    Selling some older blue chips.        9.95  USD     16    IBM
-                                                                                               -5265.05 USD
-2014-05-01  Income:US:ETrade:PnL              Selling some older blue chips.     -745.95  USD     16    IBM
-                                                                                               -6011.00 USD
+                                                                                               -2780.05 USD
+2014-05-01  Income:US:ETrade:PnL              Selling some older blue chips.      -57.95  USD     16    IBM
+                                                                                               -2838.00 USD

--- a/test-cases/trading.golden/rollup
+++ b/test-cases/trading.golden/rollup
@@ -5,7 +5,7 @@ Assets:US:ETrade:Cash                                         -2775.70
 Expenses                           69.65                              
 Expenses:Financial                           69.65                    
 Expenses:Financial:Commissions                                   69.65
-Income                          -3304.95                              
-Income:US                                 -3304.95                    
-Income:US:ETrade                                    -3304.95          
-Income:US:ETrade:PnL                                          -3304.95
+Income                           -131.95                              
+Income:US                                  -131.95                    
+Income:US:ETrade                                     -131.95          
+Income:US:ETrade:PnL                                           -131.95


### PR DESCRIPTION
Also fixed the golden test output for trading.beancount, which was previously incorrect because of the {} lot reduction bug.