### PR TITLE
Add full spec test with plugins

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Force LF-only for golden output to avoid Windows breakage
-test-cases/*.golden/* text eol=lf
+# Force LF-only for all test files to avoid Windows breakage
+test-cases/** text eol=lf

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           nix run '.#tests'
 
-
   cross-platform-tests:
     name: Run tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -43,8 +42,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: "temurin"
+          java-version: "21"
       - run: java --version
 
       - name: Setup Clojure
@@ -115,6 +114,7 @@ jobs:
           VERSION=$(bash ./scripts.dev/get-version.sh)
           export LIMABEAN_UBERJAR="./clj/target/limabean-${VERSION}-standalone.jar"
           unset LIMABEAN_CLJ_LOCAL_ROOT
+          export LIMABEAN_CLJ_DEPS="limabean/test-plugins {:local/root \"$(pwd)/clj/test-plugins\"}"
           export PATH=./rust/target/debug:$PATH
           for golden in test-cases/*.golden/{inventory,journal,rollup}; do
             query=${golden##*/}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -114,17 +114,20 @@ jobs:
           VERSION=$(bash ./scripts.dev/get-version.sh)
           export LIMABEAN_UBERJAR="./clj/target/limabean-${VERSION}-standalone.jar"
           unset LIMABEAN_CLJ_LOCAL_ROOT
-          export LIMABEAN_CLJ_DEPS="limabean/test-plugins {:local/root \"$(pwd)/clj/test-plugins\"}"
           export PATH=./rust/target/debug:$PATH
           for golden in test-cases/*.golden/{inventory,journal,rollup}; do
             query=${golden##*/}
             beanfile=${golden%.golden/$query}.beancount
-            # rollup is no longer a stand-alone query, must be applied to an inventory
-            if test "$query" == rollup; then
-              query="rollup (inventory)"
+            if test ${beanfile##*/} == full.beancount; then
+                echo "Skipping full.beancount, as uberjar test does not support plugins"
+            else
+                # rollup is no longer a stand-alone query, must be applied to an inventory
+                if test "$query" == rollup; then
+                  query="rollup (inventory)"
+                fi
+                echo "Validating $golden"
+                limabean -v --beanfile "$beanfile" --eval "(show ($query))" | diff - $golden
             fi
-            echo "Validating $golden"
-            limabean -v --beanfile "$beanfile" --eval "(show ($query))" | diff - $golden
           done
 
   check-jarfile:

--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. This change
 
 - appending :directives to filters to pass custom directives is no longer supported
 - refactoring of namespaces so limabean.user is the REPL and limabean the API
-- full.beancount test now uses identity test plugin via LIMABEAN_CLJ_DEPS
+- full.beancount test now uses identity test plugin, so skipped in uberjar tests
 
 [commit log]: https://github.com/tesujimath/limabean/compare/0.5.1...HEAD
 

--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -10,10 +10,12 @@ All notable changes to this project will be documented in this file. This change
 - {} lot reduction - limabean-booking#10
 - correct error returned when prior posting depletes inventory limabean-booking#12
 - tolerance for balance directives #103
+- metavalue numbers or amounts in the presence of plugins #106 #108
 
 ### Added
 
 - Containerfile for podman/docker #94
+- tests for spec validation with plugins
 
 ### Changed
 

--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. This change
 
 - appending :directives to filters to pass custom directives is no longer supported
 - refactoring of namespaces so limabean.user is the REPL and limabean the API
+- full.beancount test now uses identity test plugin via LIMABEAN_CLJ_DEPS
 
 [commit log]: https://github.com/tesujimath/limabean/compare/0.5.1...HEAD
 

--- a/clj/src/limabean/spec.clj
+++ b/clj/src/limabean/spec.clj
@@ -12,6 +12,8 @@
         :int int?))
 (s/def ::units ::number)
 (s/def ::cur string?)
+(s/def ::amount
+  (s/and (s/keys :req-un [::units ::cur]) #(= 2 (count (keys %)))))
 
 ;; metadata
 (s/def ::tag string?)
@@ -21,6 +23,7 @@
 
 (s/def ::metavalue
   (s/or :acc (s/map-of #{:acc} ::acc :count 1)
+        :amount ::amount
         :bool (s/map-of #{:bool} boolean? :count 1)
         :cur (s/map-of #{:cur} ::cur :count 1)
         :date (s/map-of #{:date} ::date :count 1)

--- a/clj/src/limabean/spec.clj
+++ b/clj/src/limabean/spec.clj
@@ -7,9 +7,10 @@
 ;; common fields
 (s/def ::date jt/local-date?)
 (s/def ::acc string?)
-(s/def ::units
+(s/def ::number
   (s/or :decimal decimal?
         :int int?))
+(s/def ::units ::number)
 (s/def ::cur string?)
 
 ;; metadata
@@ -25,7 +26,7 @@
         :date (s/map-of #{:date} ::date :count 1)
         :link (s/map-of #{:link} ::link :count 1)
         :null nil?
-        :number (s/map-of #{:number} (s/or :decimal decimal? :int int?) :count 1)
+        :number (s/map-of #{:number} ::number :count 1)
         :string (s/map-of #{:string} string? :count 1)
         :tag (s/map-of #{:tag} ::tag :count 1)
         :units (s/map-of #{:units} ::units :count 1)))

--- a/clj/test-plugins/src/limabean/test/plugins/identity.clj
+++ b/clj/test-plugins/src/limabean/test/plugins/identity.clj
@@ -1,0 +1,25 @@
+(ns limabean.test.plugins.identity)
+
+(defn raw-xf
+  "Identity raw plugin"
+  [_]
+  (fn [rf]
+    (fn
+      ;; init
+      ([] (rf))
+      ;; completion
+      ([result] (rf result))
+      ;; step
+      ([result dct] (rf result dct)))))
+
+(defn booked-xf
+  "Identity booked plugin"
+  [_]
+  (fn [rf]
+    (fn
+      ;; init
+      ([] (rf))
+      ;; completion
+      ([result] (rf result))
+      ;; step
+      ([result dct] (rf result dct)))))

--- a/justfile
+++ b/justfile
@@ -33,17 +33,20 @@ test-clj-offline: build-clj build-rust
     VERSION=$(bash ./scripts.dev/get-version.sh)
     export LIMABEAN_UBERJAR="./clj/target/limabean-${VERSION}-standalone.jar"
     unset LIMABEAN_CLJ_LOCAL_ROOT
-    export LIMABEAN_CLJ_DEPS="limabean/test-plugins {:local/root \"$(pwd)/clj/test-plugins\"}"
     export PATH=./rust/target/debug:$PATH
     for golden in test-cases/*.golden/{inventory,journal,rollup}; do
         query=${golden##*/}
         beanfile=${golden%.golden/$query}.beancount
-        # rollup is no longer a stand-alone query, must be applied to an inventory
-        if test "$query" == rollup; then
-          query="rollup (inventory)"
+        if test ${beanfile##*/} == full.beancount; then
+            echo "Skipping full.beancount, as uberjar test does not support plugins"
+        else
+            # rollup is no longer a stand-alone query, must be applied to an inventory
+            if test "$query" == rollup; then
+              query="rollup (inventory)"
+            fi
+            echo "Validating $golden"
+            limabean -v --beanfile "$beanfile" --eval "(show ($query))" | diff - $golden
         fi
-        echo "Validating $golden"
-        limabean -v --beanfile "$beanfile" --eval "(show ($query))" | diff - $golden
     done
 
 [working-directory: 'clj']

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ test-clj-offline: build-clj build-rust
     VERSION=$(bash ./scripts.dev/get-version.sh)
     export LIMABEAN_UBERJAR="./clj/target/limabean-${VERSION}-standalone.jar"
     unset LIMABEAN_CLJ_LOCAL_ROOT
+    export LIMABEAN_CLJ_DEPS="limabean/test-plugins {:local/root \"$(pwd)/clj/test-plugins\"}"
     export PATH=./rust/target/debug:$PATH
     for golden in test-cases/*.golden/{inventory,journal,rollup}; do
         query=${golden##*/}

--- a/test-cases/full.beancount
+++ b/test-cases/full.beancount
@@ -1,4 +1,6 @@
 ; an example Beancount file
+plugin "limabean.test.plugins.identity"
+
 * ignored line
 % another ignored line
 
@@ -12,7 +14,7 @@ option "plugin_processing_mode" "RAW"
   ;   ; New Zealand Dollar
 
 ; taken from Beancount docs, with added tag/link/metadata
-2014-07-09 price HOOL                                     579.18 USD #watcha ^cool.co
+2014-07-09 price HOOL                                                    579.18 USD #watcha ^cool.co
   heat: "on"
 
 1972-05-28 open Assets:AccountsReceivable:Taxes    USD,CAD
@@ -49,7 +51,7 @@ pushtag #essential
 pushmeta price: "expensive"
 
 2017-11-17 pad Assets:US:TD:Checking Equity:Opening-Balances
-2017-11-18 balance Assets:US:TD:Checking                23954.04 USD
+2017-11-18 balance Assets:US:TD:Checking                               23954.04 USD
 
 2012-01-09 * "VISA DDA PUR 444500     WHOLEFDS -- VISA DDA PUR 444500     WHOLEFDS HOU 10236          NEW YORK      * NY"
 
@@ -57,7 +59,7 @@ pushmeta price: "expensive"
 
 ; Martin
 2013-01-01 * "Buy CRA shares" ^old-transactions-008
-  Assets:CA:RBC-Investing:Taxable-CAD:Cash              -1395.43 CAD @ 1/1.4576 USD
+  Assets:CA:RBC-Investing:Taxable-CAD:Cash                             -1395.43 CAD @ 1/1.4576 USD
   Assets:US:TD:Checking
 
 2023-05-29 * "New World Gardens North East Va ;" ^newworld.co.nz
@@ -66,7 +68,7 @@ pushmeta price: "expensive"
   Expenses:Groceries
 
 2023-06-10 * "Transfer"
-  Assets:Bank:Current                                    -100.00 NZD
+  Assets:Bank:Current                                                   -100.00 NZD
   Assets:Bank:Savings
 
 popmeta price:
@@ -76,16 +78,16 @@ poptag #essential
 2023-05-29 pad Assets:Bank:Current Equity:Opening-Balances #fudge
   evil: "unseen"
 
-2023-05-30 balance Assets:Bank:Current          1000 ~      0.01 NZD #richman
+2023-05-30 balance Assets:Bank:Current          1000 ~                     0.01 NZD #richman
 
-2023-05-30 balance Expenses:Groceries                      39.65 NZD
+2023-05-30 balance Expenses:Groceries                                     39.65 NZD
   meals: "cheap"
 
 pushmeta drink: "alcoholic"
 
 2023-05-31 * "EMERSON S TAPROOM DUNEDIN ;"
   ; indented comment
-  Assets:Bank:Current                                     -25.00 NZD
+  Assets:Bank:Current                                                    -25.00 NZD
   ofxid: "0.12-3456-1234567-01.31May2023.3"
   Expenses:Entertainment:Drinks-and-snacks
   #mytag1
@@ -127,7 +129,7 @@ popmeta drink:
 
 2022-01-30 * "Z Energy ;" #petrol
   #car
-  Assets:Bank:Current                                    -125.00 NZD
+  Assets:Bank:Current                                                   -125.00 NZD
   ofxid: "0.12-3456-1234567-01.31May2023.3"
   Expenses:Car:Fuel
 
@@ -136,13 +138,13 @@ popmeta drink:
   ! Expenses:Car:Fuel
 
 2023-06-02 * "Repco" ""
-  Assets:Bank:Current                                     -25.00 NZD
+  Assets:Bank:Current                                                    -25.00 NZD
   Expenses:Car
 
 2024-02-16 * "Buying some IBM"
-  Assets:US:ETrade:IBM                                        10 IBM {160.00 USD, "first\nsecond"}
+  Assets:US:ETrade:IBM                                                       10 IBM {160.00 USD, "first\nsecond"}
   Assets:US:ETrade:Cash
-  Expenses:Financial:Commissions                            9.95 USD
+  Expenses:Financial:Commissions                                           9.95 USD
 
 2025-01-01 query "fictional SQL" "SELECT money FROM accounts;" #for-testing
   status: "bogus"

--- a/test-cases/full.golden/directives.edn
+++ b/test-cases/full.golden/directives.edn
@@ -1,0 +1,258 @@
+[{:cur "NZD",
+  :date #time/date "1970-01-01",
+  :dct :commodity,
+  :links #{"money.co.nz"},
+  :tags #{"downunder"}}
+ {:acc "Assets:AccountsReceivable:Taxes",
+  :currencies #{"CAD" "USD"},
+  :date #time/date "1972-05-28",
+  :dct :open}
+ {:acc "Assets:US:TD:Checking",
+  :currencies #{"USD"},
+  :date #time/date "1972-05-28",
+  :dct :open}
+ {:acc "Equity:Opening-Balances", :date #time/date "1972-05-28", :dct :open}
+ {:acc "Assets:US:ETrade:IBM", :date #time/date "2010-03-01", :dct :open}
+ {:acc "Expenses:Financial:Commissions",
+  :date #time/date "2010-03-01",
+  :dct :open}
+ {:acc "Assets:US:ETrade:Cash", :date #time/date "2010-03-01", :dct :open}
+ {:date #time/date "2012-01-09",
+  :dct :txn,
+  :flag "*",
+  :metadata {:price {:string "expensive"}},
+  :narration
+    "VISA DDA PUR 444500     WHOLEFDS -- VISA DDA PUR 444500     WHOLEFDS HOU 10236          NEW YORK      * NY",
+  :postings [],
+  :tags #{"essential"}}
+ {:acc "Assets:CA:RBC-Investing:Taxable-CAD:Cash",
+  :currencies #{"CAD"},
+  :date #time/date "2013-01-01",
+  :dct :open,
+  :metadata {:price {:string "expensive"}},
+  :tags #{"essential"}}
+ {:date #time/date "2013-01-01",
+  :dct :txn,
+  :flag "*",
+  :links #{"old-transactions-008"},
+  :metadata {:price {:string "expensive"}},
+  :narration "Buy CRA shares",
+  :postings [{:acc "Assets:CA:RBC-Investing:Taxable-CAD:Cash",
+              :cur "CAD",
+              :price {:cur "USD", :per-unit 0.6861M, :total -957.404523M},
+              :units -1395.43M}
+             {:acc "Assets:US:TD:Checking", :cur "USD", :units 957.40M}],
+  :tags #{"essential"}}
+ {:cur "HOOL",
+  :date #time/date "2014-07-09",
+  :dct :price,
+  :links #{"cool.co"},
+  :metadata {:heat {:string "on"}},
+  :price {:cur "USD", :per-unit 579.18M},
+  :tags #{"watcha"}}
+ {:acc "Assets:Bank:Savings", :date #time/date "2016-03-01", :dct :open}
+ {:acc "Assets:Bank:Current",
+  :currencies #{"NZD"},
+  :date #time/date "2016-03-01",
+  :dct :open,
+  :links #{"www.bank.com"},
+  :tags #{"money"}}
+ {:acc "Expenses:Groceries",
+  :booking :fifo,
+  :currencies #{"NZD"},
+  :date #time/date "2016-03-01",
+  :dct :open}
+ {:acc "Expenses:Entertainment:Drinks-and-snacks",
+  :booking :strict-with-size,
+  :date #time/date "2016-03-01",
+  :dct :open}
+ {:acc "Assets:US:TD:Checking",
+  :date #time/date "2017-11-17",
+  :dct :pad,
+  :metadata {:price {:string "expensive"}},
+  :source "Equity:Opening-Balances",
+  :tags #{"essential"}}
+ {:date #time/date "2017-11-17",
+  :dct :txn,
+  :flag "'P",
+  :metadata {:price {:string "expensive"}},
+  :postings
+    [{:acc "Assets:US:TD:Checking", :cur "USD", :flag "'P", :units 22996.64M}
+     {:acc "Equity:Opening-Balances",
+      :cur "USD",
+      :flag "'P",
+      :units -22996.64M}],
+  :tags #{"essential"}}
+ {:acc "Assets:US:TD:Checking",
+  :cur "USD",
+  :date #time/date "2017-11-18",
+  :dct :balance,
+  :metadata {:price {:string "expensive"}},
+  :tags #{"essential"},
+  :units 23954.04M}
+ {:acc "Expenses:Car",
+  :currencies #{"NZD"},
+  :date #time/date "2022-01-30",
+  :dct :open}
+ {:acc "Expenses:Car:Fuel",
+  :currencies #{"NZD"},
+  :date #time/date "2022-01-30",
+  :dct :open}
+ {:date #time/date "2022-01-30",
+  :dct :txn,
+  :flag "*",
+  :narration "Z Energy ;",
+  :postings [{:acc "Assets:Bank:Current",
+              :cur "NZD",
+              :metadata {:ofxid {:string "0.12-3456-1234567-01.31May2023.3"}},
+              :units -125.00M}
+             {:acc "Expenses:Car:Fuel", :cur "NZD", :units 125.00M}],
+  :tags #{"car" "petrol"}}
+ {:date #time/date "2023-05-28",
+  :dct :event,
+  :description "Plan beers",
+  :metadata {:accounted-in {:acc "Expenses:Groceries"},
+             :budget {:cur "NZD", :units 127.50M},
+             :date {:date #time/date "2023-05-27"},
+             :drink {:string "alcoholic"},
+             :exciting {:bool true},
+             :foreigners {:cur "CAD"},
+             :guests-expected {:number 150},
+             :linked-to {:link "mylink"},
+             :pre-dated {:date #time/date "2023-06-01"},
+             :state {:string "anticipation"},
+             :tagged-with {:tag "mytag"},
+             :wahoo nil},
+  :tags #{"exciting"},
+  :type "planning"}
+ {:date #time/date "2023-05-29",
+  :dct :txn,
+  :flag "*",
+  :links #{"newworld.co.nz"},
+  :metadata {:price {:string "expensive"}},
+  :narration "New World Gardens North East Va ;",
+  :postings [{:acc "Assets:Bank:Current",
+              :cur "NZD",
+              :metadata {:ofxid {:string "0.12-3456-1234567-01.29May2023.1"}},
+              :units -39.65M}
+             {:acc "Expenses:Groceries", :cur "NZD", :units 39.65M}],
+  :tags #{"essential"}}
+ {:acc "Assets:Bank:Current",
+  :date #time/date "2023-05-29",
+  :dct :pad,
+  :metadata {:evil {:string "unseen"}},
+  :source "Equity:Opening-Balances",
+  :tags #{"fudge"}}
+ {:date #time/date "2023-05-29",
+  :dct :txn,
+  :flag "'P",
+  :metadata {:evil {:string "unseen"}},
+  :postings
+    [{:acc "Assets:Bank:Current", :cur "NZD", :flag "'P", :units 1164.65M}
+     {:acc "Equity:Opening-Balances",
+      :cur "NZD",
+      :flag "'P",
+      :units -1164.65M}],
+  :tags #{"fudge"}}
+ {:acc "Assets:Bank:Current",
+  :cur "NZD",
+  :date #time/date "2023-05-30",
+  :dct :balance,
+  :tags #{"richman"},
+  :tolerance 0.01M,
+  :units 1000}
+ {:acc "Expenses:Groceries",
+  :cur "NZD",
+  :date #time/date "2023-05-30",
+  :dct :balance,
+  :metadata {:meals {:string "cheap"}},
+  :units 39.65M}
+ {:date #time/date "2023-05-31",
+  :dct :txn,
+  :flag "*",
+  :metadata {:drink {:string "alcoholic"}},
+  :narration "EMERSON S TAPROOM DUNEDIN ;",
+  :postings [{:acc "Assets:Bank:Current",
+              :cur "NZD",
+              :metadata {:ofxid {:string "0.12-3456-1234567-01.31May2023.3"}},
+              :units -25.00M}
+             {:acc "Expenses:Entertainment:Drinks-and-snacks",
+              :cur "NZD",
+              :links #{"mylink1"},
+              :metadata {:date {:string "2023-05-30"},
+                         :just-use-a-tag {:tag "mytag"},
+                         :key-for-link {:link "mylink"},
+                         :open {:string "for business"},
+                         :related_account {:acc "Expenses:Groceries"}},
+              :tags #{"mytag1"},
+              :units 25.00M}]}
+ {:acc "Expenses:Entertainment:Drinks-and-snacks",
+  :date #time/date "2023-05-31",
+  :dct :document,
+  :metadata {:assessment {:string "worth-it"}, :drink {:string "alcoholic"}},
+  :path "2023-05-31-emersons-receipt.png",
+  :tags #{"beer"}}
+ {:acc "Expenses:Entertainment:Drinks-and-snacks",
+  :comment
+    "met with Mickey and Minnie\n  *  Pluto couldn't come,\n  ;  which made me sad.\n  ",
+  :date #time/date "2023-05-31",
+  :dct :note,
+  :metadata {:drink {:string "alcoholic"}}}
+ {:date #time/date "2023-05-31",
+  :dct :txn,
+  :flag "'Z",
+  :narration "Rather expensive",
+  :payee "Z Energy ;",
+  :postings
+    [{:acc "Assets:Bank:Current", :cur "NZD", :flag "'B", :units -130.00M}
+     {:acc "Expenses:Car:Fuel", :cur "NZD", :flag "!", :units 130.00M}],
+  :tags #{"petrol"}}
+ {:date #time/date "2023-06-02",
+  :dct :txn,
+  :flag "*",
+  :payee "Repco",
+  :postings [{:acc "Assets:Bank:Current", :cur "NZD", :units -25.00M}
+             {:acc "Expenses:Car", :cur "NZD", :units 25.00M}]}
+ {:date #time/date "2023-06-10",
+  :dct :txn,
+  :flag "*",
+  :metadata {:price {:string "expensive"}},
+  :narration "Transfer",
+  :postings [{:acc "Assets:Bank:Current", :cur "NZD", :units -100.00M}
+             {:acc "Assets:Bank:Savings", :cur "NZD", :units 100.00M}],
+  :tags #{"essential"}}
+ {:date #time/date "2024-02-16",
+  :dct :txn,
+  :flag "*",
+  :narration "Buying some IBM",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost {:cur "USD",
+                     :date #time/date "2024-02-16",
+                     :label "first\nsecond",
+                     :per-unit 160.00M,
+                     :total 1600.00M},
+              :cur "IBM",
+              :units 10}
+             {:acc "Assets:US:ETrade:Cash", :cur "USD", :units -1609.95M}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}]}
+ {:acc "Assets:Bank:Current",
+  :date #time/date "2024-03-01",
+  :dct :close,
+  :links #{"solong.and.thanks"},
+  :tags #{"seeya"}}
+ {:content "SELECT money FROM accounts;",
+  :date #time/date "2025-01-01",
+  :dct :query,
+  :metadata {:status {:string "bogus"}},
+  :name "fictional SQL",
+  :tags #{"for-testing"}}
+ {:date #time/date "2025-02-10",
+  :dct :custom,
+  :links #{"i-am-a-meta-link"},
+  :metadata {:i-am-meta {:string "yay!"}},
+  :tags #{"i-am-a-meta-tag"},
+  :type "all the things!",
+  :values [{:cur "USD", :units 10.50M} {:string "anticipation"} {:cur "CAD"}
+           {:acc "Expenses:Groceries"} {:tag "my-custom-tag"}
+           {:link "my-custom-link"} {:date #time/date "2023-06-01"} {:bool true}
+           {:number 150}]}]

--- a/test-cases/full.golden/directives.fyi.beancount
+++ b/test-cases/full.golden/directives.fyi.beancount
@@ -1,0 +1,140 @@
+1970-01-01 commodity NZD #downunder ^money.co.nz
+
+1972-05-28 open Assets:AccountsReceivable:Taxes CAD,USD
+
+1972-05-28 open Assets:US:TD:Checking USD
+
+1972-05-28 open Equity:Opening-Balances
+
+2010-03-01 open Assets:US:ETrade:IBM
+
+2010-03-01 open Expenses:Financial:Commissions
+
+2010-03-01 open Assets:US:ETrade:Cash
+
+2012-01-09 * "VISA DDA PUR 444500     WHOLEFDS -- VISA DDA PUR 444500     WHOLEFDS HOU 10236          NEW YORK      * NY" #essential
+  price: "expensive"
+
+2013-01-01 open Assets:CA:RBC-Investing:Taxable-CAD:Cash CAD #essential
+  price: "expensive"
+
+2013-01-01 * "Buy CRA shares" #essential ^old-transactions-008
+  price: "expensive"
+  Assets:CA:RBC-Investing:Taxable-CAD:Cash -1395.43 CAD @ 0.6861 USD
+  Assets:US:TD:Checking 957.40 USD
+
+2014-07-09 price HOOL 579.18 USD #watcha ^cool.co
+  heat: "on"
+
+2016-03-01 open Assets:Bank:Savings
+
+2016-03-01 open Assets:Bank:Current NZD #money ^www.bank.com
+
+2016-03-01 open Expenses:Groceries NZD "FIFO"
+
+2016-03-01 open Expenses:Entertainment:Drinks-and-snacks "STRICT_WITH_SIZE"
+
+2017-11-17 pad Assets:US:TD:Checking Equity:Opening-Balances #essential
+  price: "expensive"
+
+2017-11-17 'P #essential
+  price: "expensive"
+  'P Assets:US:TD:Checking 22996.64 USD
+  'P Equity:Opening-Balances -22996.64 USD
+
+2017-11-18 balance Assets:US:TD:Checking 23954.04 USD #essential
+  price: "expensive"
+
+2022-01-30 open Expenses:Car NZD
+
+2022-01-30 open Expenses:Car:Fuel NZD
+
+2022-01-30 * "Z Energy ;" #car #petrol
+  Assets:Bank:Current -125.00 NZD
+  ofxid: "0.12-3456-1234567-01.31May2023.3"
+  Expenses:Car:Fuel 125.00 NZD
+
+2023-05-28 event "planning" "Plan beers" #exciting
+  accounted-in: Expenses:Groceries
+  budget: 127.50 NZD
+  date: 2023-05-27
+  drink: "alcoholic"
+  exciting: TRUE
+  foreigners: CAD
+  guests-expected: 150
+  linked-to: ^mylink
+  pre-dated: 2023-06-01
+  state: "anticipation"
+  tagged-with: #mytag
+  wahoo:
+
+2023-05-29 * "New World Gardens North East Va ;" #essential ^newworld.co.nz
+  price: "expensive"
+  Assets:Bank:Current -39.65 NZD
+  ofxid: "0.12-3456-1234567-01.29May2023.1"
+  Expenses:Groceries 39.65 NZD
+
+2023-05-29 pad Assets:Bank:Current Equity:Opening-Balances #fudge
+  evil: "unseen"
+
+2023-05-29 'P #fudge
+  evil: "unseen"
+  'P Assets:Bank:Current 1164.65 NZD
+  'P Equity:Opening-Balances -1164.65 NZD
+
+2023-05-30 balance Assets:Bank:Current 1000 NZD ~ 0.01 #richman
+
+2023-05-30 balance Expenses:Groceries 39.65 NZD
+  meals: "cheap"
+
+2023-05-31 * "EMERSON S TAPROOM DUNEDIN ;"
+  drink: "alcoholic"
+  Assets:Bank:Current -25.00 NZD
+  ofxid: "0.12-3456-1234567-01.31May2023.3"
+  Expenses:Entertainment:Drinks-and-snacks 25.00 NZD
+  #mytag1
+  ^mylink1
+  date: "2023-05-30"
+  just-use-a-tag: #mytag
+  key-for-link: ^mylink
+  open: "for business"
+  related_account: Expenses:Groceries
+
+2023-05-31 document Expenses:Entertainment:Drinks-and-snacks "2023-05-31-emersons-receipt.png" #beer
+  assessment: "worth-it"
+  drink: "alcoholic"
+
+2023-05-31 note Expenses:Entertainment:Drinks-and-snacks "met with Mickey and Minnie
+  *  Pluto couldn't come,
+  ;  which made me sad.
+  "
+  drink: "alcoholic"
+
+2023-05-31 'Z "Z Energy ;" "Rather expensive" #petrol
+  'B Assets:Bank:Current -130.00 NZD
+  ! Expenses:Car:Fuel 130.00 NZD
+
+2023-06-02 * "Repco" ""
+  Assets:Bank:Current -25.00 NZD
+  Expenses:Car 25.00 NZD
+
+2023-06-10 * "Transfer" #essential
+  price: "expensive"
+  Assets:Bank:Current -100.00 NZD
+  Assets:Bank:Savings 100.00 NZD
+
+2024-02-16 * "Buying some IBM"
+  Assets:US:ETrade:IBM 10 IBM {160.00 USD, 2024-02-16, "first
+second"}
+  Assets:US:ETrade:Cash -1609.95 USD
+  Expenses:Financial:Commissions 9.95 USD
+
+2024-03-01 close Assets:Bank:Current #seeya ^solong.and.thanks
+
+2025-01-01 query "fictional SQL" "SELECT money FROM accounts;" #for-testing
+  status: "bogus"
+
+2025-02-10 custom "all the things!" 10.50 USD "anticipation" CAD Expenses:Groceries #my-custom-tag ^my-custom-link 2023-06-01 TRUE 150
+  #i-am-a-meta-tag
+  ^i-am-a-meta-link
+  i-am-meta: "yay!"

--- a/test-cases/full.golden/raw-xf-directives.edn
+++ b/test-cases/full.golden/raw-xf-directives.edn
@@ -1,0 +1,227 @@
+[{:cur "NZD",
+  :date #time/date "1970-01-01",
+  :dct :commodity,
+  :links #{"money.co.nz"},
+  :tags #{"downunder"}}
+ {:acc "Assets:AccountsReceivable:Taxes",
+  :currencies #{"CAD" "USD"},
+  :date #time/date "1972-05-28",
+  :dct :open}
+ {:acc "Assets:US:TD:Checking",
+  :currencies #{"USD"},
+  :date #time/date "1972-05-28",
+  :dct :open}
+ {:acc "Equity:Opening-Balances", :date #time/date "1972-05-28", :dct :open}
+ {:acc "Assets:US:ETrade:IBM", :date #time/date "2010-03-01", :dct :open}
+ {:acc "Expenses:Financial:Commissions",
+  :date #time/date "2010-03-01",
+  :dct :open}
+ {:acc "Assets:US:ETrade:Cash", :date #time/date "2010-03-01", :dct :open}
+ {:date #time/date "2012-01-09",
+  :dct :txn,
+  :flag "*",
+  :metadata {:price {:string "expensive"}},
+  :narration
+    "VISA DDA PUR 444500     WHOLEFDS -- VISA DDA PUR 444500     WHOLEFDS HOU 10236          NEW YORK      * NY",
+  :postings [],
+  :tags #{"essential"}}
+ {:acc "Assets:CA:RBC-Investing:Taxable-CAD:Cash",
+  :currencies #{"CAD"},
+  :date #time/date "2013-01-01",
+  :dct :open,
+  :metadata {:price {:string "expensive"}},
+  :tags #{"essential"}}
+ {:date #time/date "2013-01-01",
+  :dct :txn,
+  :flag "*",
+  :links #{"old-transactions-008"},
+  :metadata {:price {:string "expensive"}},
+  :narration "Buy CRA shares",
+  :postings [{:acc "Assets:CA:RBC-Investing:Taxable-CAD:Cash",
+              :cur "CAD",
+              :price-spec {:cur "USD", :per-unit 0.6861M},
+              :units -1395.43M} {:acc "Assets:US:TD:Checking"}],
+  :tags #{"essential"}}
+ {:cur "HOOL",
+  :date #time/date "2014-07-09",
+  :dct :price,
+  :links #{"cool.co"},
+  :metadata {:heat {:string "on"}},
+  :price {:cur "USD", :per-unit 579.18M},
+  :tags #{"watcha"}}
+ {:acc "Assets:Bank:Savings", :date #time/date "2016-03-01", :dct :open}
+ {:acc "Assets:Bank:Current",
+  :currencies #{"NZD"},
+  :date #time/date "2016-03-01",
+  :dct :open,
+  :links #{"www.bank.com"},
+  :tags #{"money"}}
+ {:acc "Expenses:Groceries",
+  :booking :fifo,
+  :currencies #{"NZD"},
+  :date #time/date "2016-03-01",
+  :dct :open}
+ {:acc "Expenses:Entertainment:Drinks-and-snacks",
+  :booking :strict-with-size,
+  :date #time/date "2016-03-01",
+  :dct :open}
+ {:acc "Assets:US:TD:Checking",
+  :date #time/date "2017-11-17",
+  :dct :pad,
+  :metadata {:price {:string "expensive"}},
+  :source "Equity:Opening-Balances",
+  :tags #{"essential"}}
+ {:acc "Assets:US:TD:Checking",
+  :cur "USD",
+  :date #time/date "2017-11-18",
+  :dct :balance,
+  :metadata {:price {:string "expensive"}},
+  :tags #{"essential"},
+  :units 23954.04M}
+ {:acc "Expenses:Car",
+  :currencies #{"NZD"},
+  :date #time/date "2022-01-30",
+  :dct :open}
+ {:acc "Expenses:Car:Fuel",
+  :currencies #{"NZD"},
+  :date #time/date "2022-01-30",
+  :dct :open}
+ {:date #time/date "2022-01-30",
+  :dct :txn,
+  :flag "*",
+  :narration "Z Energy ;",
+  :postings [{:acc "Assets:Bank:Current",
+              :cur "NZD",
+              :metadata {:ofxid {:string "0.12-3456-1234567-01.31May2023.3"}},
+              :units -125.00M} {:acc "Expenses:Car:Fuel"}],
+  :tags #{"car" "petrol"}}
+ {:date #time/date "2023-05-28",
+  :dct :event,
+  :description "Plan beers",
+  :metadata {:accounted-in {:acc "Expenses:Groceries"},
+             :budget {:cur "NZD", :units 127.50M},
+             :date {:date #time/date "2023-05-27"},
+             :drink {:string "alcoholic"},
+             :exciting {:bool true},
+             :foreigners {:cur "CAD"},
+             :guests-expected {:number 150},
+             :linked-to {:link "mylink"},
+             :pre-dated {:date #time/date "2023-06-01"},
+             :state {:string "anticipation"},
+             :tagged-with {:tag "mytag"},
+             :wahoo nil},
+  :tags #{"exciting"},
+  :type "planning"}
+ {:date #time/date "2023-05-29",
+  :dct :txn,
+  :flag "*",
+  :links #{"newworld.co.nz"},
+  :metadata {:price {:string "expensive"}},
+  :narration "New World Gardens North East Va ;",
+  :postings [{:acc "Assets:Bank:Current",
+              :cur "NZD",
+              :metadata {:ofxid {:string "0.12-3456-1234567-01.29May2023.1"}},
+              :units -39.65M} {:acc "Expenses:Groceries"}],
+  :tags #{"essential"}}
+ {:acc "Assets:Bank:Current",
+  :date #time/date "2023-05-29",
+  :dct :pad,
+  :metadata {:evil {:string "unseen"}},
+  :source "Equity:Opening-Balances",
+  :tags #{"fudge"}}
+ {:acc "Assets:Bank:Current",
+  :cur "NZD",
+  :date #time/date "2023-05-30",
+  :dct :balance,
+  :tags #{"richman"},
+  :tolerance 0.01M,
+  :units 1000}
+ {:acc "Expenses:Groceries",
+  :cur "NZD",
+  :date #time/date "2023-05-30",
+  :dct :balance,
+  :metadata {:meals {:string "cheap"}},
+  :units 39.65M}
+ {:date #time/date "2023-05-31",
+  :dct :txn,
+  :flag "*",
+  :metadata {:drink {:string "alcoholic"}},
+  :narration "EMERSON S TAPROOM DUNEDIN ;",
+  :postings [{:acc "Assets:Bank:Current",
+              :cur "NZD",
+              :metadata {:ofxid {:string "0.12-3456-1234567-01.31May2023.3"}},
+              :units -25.00M}
+             {:acc "Expenses:Entertainment:Drinks-and-snacks",
+              :links #{"mylink1"},
+              :metadata {:date {:string "2023-05-30"},
+                         :just-use-a-tag {:tag "mytag"},
+                         :key-for-link {:link "mylink"},
+                         :open {:string "for business"},
+                         :related_account {:acc "Expenses:Groceries"}},
+              :tags #{"mytag1"}}]}
+ {:acc "Expenses:Entertainment:Drinks-and-snacks",
+  :date #time/date "2023-05-31",
+  :dct :document,
+  :metadata {:assessment {:string "worth-it"}, :drink {:string "alcoholic"}},
+  :path "2023-05-31-emersons-receipt.png",
+  :tags #{"beer"}}
+ {:acc "Expenses:Entertainment:Drinks-and-snacks",
+  :comment
+    "met with Mickey and Minnie\n  *  Pluto couldn't come,\n  ;  which made me sad.\n  ",
+  :date #time/date "2023-05-31",
+  :dct :note,
+  :metadata {:drink {:string "alcoholic"}}}
+ {:date #time/date "2023-05-31",
+  :dct :txn,
+  :flag "'Z",
+  :narration "Rather expensive",
+  :payee "Z Energy ;",
+  :postings
+    [{:acc "Assets:Bank:Current", :cur "NZD", :flag "'B", :units -130.00M}
+     {:acc "Expenses:Car:Fuel", :flag "!"}],
+  :tags #{"petrol"}}
+ {:date #time/date "2023-06-02",
+  :dct :txn,
+  :flag "*",
+  :payee "Repco",
+  :postings [{:acc "Assets:Bank:Current", :cur "NZD", :units -25.00M}
+             {:acc "Expenses:Car"}]}
+ {:date #time/date "2023-06-10",
+  :dct :txn,
+  :flag "*",
+  :metadata {:price {:string "expensive"}},
+  :narration "Transfer",
+  :postings [{:acc "Assets:Bank:Current", :cur "NZD", :units -100.00M}
+             {:acc "Assets:Bank:Savings"}],
+  :tags #{"essential"}}
+ {:date #time/date "2024-02-16",
+  :dct :txn,
+  :flag "*",
+  :narration "Buying some IBM",
+  :postings [{:acc "Assets:US:ETrade:IBM",
+              :cost-spec
+                {:cur "USD", :label "first\nsecond", :per-unit 160.00M},
+              :cur "IBM",
+              :units 10} {:acc "Assets:US:ETrade:Cash"}
+             {:acc "Expenses:Financial:Commissions", :cur "USD", :units 9.95M}]}
+ {:acc "Assets:Bank:Current",
+  :date #time/date "2024-03-01",
+  :dct :close,
+  :links #{"solong.and.thanks"},
+  :tags #{"seeya"}}
+ {:content "SELECT money FROM accounts;",
+  :date #time/date "2025-01-01",
+  :dct :query,
+  :metadata {:status {:string "bogus"}},
+  :name "fictional SQL",
+  :tags #{"for-testing"}}
+ {:date #time/date "2025-02-10",
+  :dct :custom,
+  :links #{"i-am-a-meta-link"},
+  :metadata {:i-am-meta {:string "yay!"}},
+  :tags #{"i-am-a-meta-tag"},
+  :type "all the things!",
+  :values [{:cur "USD", :units 10.50M} {:string "anticipation"} {:cur "CAD"}
+           {:acc "Expenses:Groceries"} {:tag "my-custom-tag"}
+           {:link "my-custom-link"} {:date #time/date "2023-06-01"} {:bool true}
+           {:number 150}]}]

--- a/test-cases/full.golden/raw-xf-directives.fyi.beancount
+++ b/test-cases/full.golden/raw-xf-directives.fyi.beancount
@@ -1,0 +1,130 @@
+1970-01-01 commodity NZD #downunder ^money.co.nz
+
+1972-05-28 open Assets:AccountsReceivable:Taxes CAD,USD
+
+1972-05-28 open Assets:US:TD:Checking USD
+
+1972-05-28 open Equity:Opening-Balances
+
+2010-03-01 open Assets:US:ETrade:IBM
+
+2010-03-01 open Expenses:Financial:Commissions
+
+2010-03-01 open Assets:US:ETrade:Cash
+
+2012-01-09 * "VISA DDA PUR 444500     WHOLEFDS -- VISA DDA PUR 444500     WHOLEFDS HOU 10236          NEW YORK      * NY" #essential
+  price: "expensive"
+
+2013-01-01 open Assets:CA:RBC-Investing:Taxable-CAD:Cash CAD #essential
+  price: "expensive"
+
+2013-01-01 * "Buy CRA shares" #essential ^old-transactions-008
+  price: "expensive"
+  Assets:CA:RBC-Investing:Taxable-CAD:Cash -1395.43 CAD @ 0.6861 USD
+  Assets:US:TD:Checking
+
+2014-07-09 price HOOL 579.18 USD #watcha ^cool.co
+  heat: "on"
+
+2016-03-01 open Assets:Bank:Savings
+
+2016-03-01 open Assets:Bank:Current NZD #money ^www.bank.com
+
+2016-03-01 open Expenses:Groceries NZD "FIFO"
+
+2016-03-01 open Expenses:Entertainment:Drinks-and-snacks "STRICT_WITH_SIZE"
+
+2017-11-17 pad Assets:US:TD:Checking Equity:Opening-Balances #essential
+  price: "expensive"
+
+2017-11-18 balance Assets:US:TD:Checking 23954.04 USD #essential
+  price: "expensive"
+
+2022-01-30 open Expenses:Car NZD
+
+2022-01-30 open Expenses:Car:Fuel NZD
+
+2022-01-30 * "Z Energy ;" #car #petrol
+  Assets:Bank:Current -125.00 NZD
+  ofxid: "0.12-3456-1234567-01.31May2023.3"
+  Expenses:Car:Fuel
+
+2023-05-28 event "planning" "Plan beers" #exciting
+  accounted-in: Expenses:Groceries
+  budget: 127.50 NZD
+  date: 2023-05-27
+  drink: "alcoholic"
+  exciting: TRUE
+  foreigners: CAD
+  guests-expected: 150
+  linked-to: ^mylink
+  pre-dated: 2023-06-01
+  state: "anticipation"
+  tagged-with: #mytag
+  wahoo:
+
+2023-05-29 * "New World Gardens North East Va ;" #essential ^newworld.co.nz
+  price: "expensive"
+  Assets:Bank:Current -39.65 NZD
+  ofxid: "0.12-3456-1234567-01.29May2023.1"
+  Expenses:Groceries
+
+2023-05-29 pad Assets:Bank:Current Equity:Opening-Balances #fudge
+  evil: "unseen"
+
+2023-05-30 balance Assets:Bank:Current 1000 NZD ~ 0.01 #richman
+
+2023-05-30 balance Expenses:Groceries 39.65 NZD
+  meals: "cheap"
+
+2023-05-31 * "EMERSON S TAPROOM DUNEDIN ;"
+  drink: "alcoholic"
+  Assets:Bank:Current -25.00 NZD
+  ofxid: "0.12-3456-1234567-01.31May2023.3"
+  Expenses:Entertainment:Drinks-and-snacks
+  #mytag1
+  ^mylink1
+  date: "2023-05-30"
+  just-use-a-tag: #mytag
+  key-for-link: ^mylink
+  open: "for business"
+  related_account: Expenses:Groceries
+
+2023-05-31 document Expenses:Entertainment:Drinks-and-snacks "2023-05-31-emersons-receipt.png" #beer
+  assessment: "worth-it"
+  drink: "alcoholic"
+
+2023-05-31 note Expenses:Entertainment:Drinks-and-snacks "met with Mickey and Minnie
+  *  Pluto couldn't come,
+  ;  which made me sad.
+  "
+  drink: "alcoholic"
+
+2023-05-31 'Z "Z Energy ;" "Rather expensive" #petrol
+  'B Assets:Bank:Current -130.00 NZD
+  ! Expenses:Car:Fuel
+
+2023-06-02 * "Repco" ""
+  Assets:Bank:Current -25.00 NZD
+  Expenses:Car
+
+2023-06-10 * "Transfer" #essential
+  price: "expensive"
+  Assets:Bank:Current -100.00 NZD
+  Assets:Bank:Savings
+
+2024-02-16 * "Buying some IBM"
+  Assets:US:ETrade:IBM 10 IBM {160.00 USD, "first
+second"}
+  Assets:US:ETrade:Cash
+  Expenses:Financial:Commissions 9.95 USD
+
+2024-03-01 close Assets:Bank:Current #seeya ^solong.and.thanks
+
+2025-01-01 query "fictional SQL" "SELECT money FROM accounts;" #for-testing
+  status: "bogus"
+
+2025-02-10 custom "all the things!" 10.50 USD "anticipation" CAD Expenses:Groceries #my-custom-tag ^my-custom-link 2023-06-01 TRUE 150
+  #i-am-a-meta-tag
+  ^i-am-a-meta-link
+  i-am-meta: "yay!"


### PR DESCRIPTION
Add an identity plugin, used in full.beancount, to trigger spec validation for the full example.

Fix the breakage this revealed.

Fixes #108 