### PR TITLE
Remove native Windows as a supported platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Force LF-only for all test files to avoid Windows breakage
-test-cases/** text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    defaults:
-      run:
-        shell: bash
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -50,24 +47,11 @@ jobs:
           cd rust
           cargo build --release --all-targets
 
-      - name: Package binaries (Unix-like)
-        if: runner.os != 'Windows'
+      - name: Package binaries
         run: |
           mkdir -p release
           cp rust/target/release/{limabean,limabean-pod} release/
           tar czvf limabean-${{ matrix.os }}.tar.gz -C release .
-
-      - name: Package binaries (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          mkdir -p release
-          $bins = @(
-            "rust\target\release\limabean.exe",
-            "rust\target\release\limabean-pod.exe"
-          )
-          Copy-Item $bins release\
-          Compress-Archive -Path release\* -DestinationPath limabean-${{ matrix.os }}.zip
 
       - name: Upload Rust binaries
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,10 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    defaults:
-      run:
-        shell: bash
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Rust is purely used for parsing and the booking algorithm, with essentially no v
 - [Design and rationale](clj/doc/70-design-and-rationale.md)
 - [Reference manual](https://tesujimath.github.io/limabean)
 
+`limabean` runs natively on Linux and macOS.  For Windows, it requires Windows Subsystem for Linux (WSL).
+
 Also, for a new approach to import see [limabean-harvest](https://github.com/tesujimath/limabean-harvest).
 
 Note for developers: the limabean implementation of the **Beancount booking algorithm** is [limabean-booking](https://github.com/tesujimath/limabean-booking), a [separate crate](https://crates.io/crates/limabean-booking) which is entirely generic, having no dependencies on either the Lima parser types nor limabean itself.

--- a/clj/CHANGELOG.md
+++ b/clj/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Changed
 
+- removed native Windows as a supported platform in favour of WSL #114
 - appending :directives to filters to pass custom directives is no longer supported
 - refactoring of namespaces so limabean.user is the REPL and limabean the API
 - full.beancount test now uses identity test plugin, so skipped in uberjar tests

--- a/clj/doc/20-installation.md
+++ b/clj/doc/20-installation.md
@@ -60,7 +60,7 @@ The corresponding `limabean` Clojure code is downloaded automatically on first r
 
 Options for installing the Rust binaries:
 
-1. Tarballs and zipfiles are provided for each [GitHub release](https://github.com/tesujimath/limabean/releases) for Linux, macOS, and Windows
+1. Tarballs and zipfiles are provided for each [GitHub release](https://github.com/tesujimath/limabean/releases) for Linux and macOS.
 
 2. If you have a Rust toolchain installed, `cargo install limabean` will install the two binaries `limabean` and `limabean-pod` into `~/.cargo/bin`.  Add this directory to your path before running `limabean`
 
@@ -74,10 +74,7 @@ xattr -rd com.apple.quarantine ./limabean/bin
 
 ### Windows
 
-- install [OpenJDK 25 MSI](https://learn.microsoft.com/en-us/java/openjdk/download)
-- install [Clojure 1.12 MSI](https://github.com/casselc/clj-msi)
-- download limabean zipfile from GitHub releases and extract somewhere
-- add that directory to path
+Native Windows is no longer supported.  Ubuntu on WSL 2 is recommended as an alternative on that platform.
 
 ## Standalone
 

--- a/rust/src/bin/limabean/run.rs
+++ b/rust/src/bin/limabean/run.rs
@@ -112,37 +112,6 @@ fn run_or_fail(mut cmd: Command) {
     std::process::exit(1);
 }
 
-#[cfg(windows)]
-fn run_or_fail(mut cmd: Command) {
-    let cmd = cmd
-        .stdin(std::process::Stdio::inherit())
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit());
-
-    match cmd.spawn() {
-        Ok(mut child) => {
-            let exit_status = child
-                .wait()
-                .unwrap_or_else(|e| panic!("limabean unexpected wait failure: {}", e));
-
-            // any error message is already written on stderr, so we're done
-            // TODO improve error path here, early exit is nasty
-            if !exit_status.success() {
-                std::process::exit(exit_status.code().unwrap_or(1));
-            }
-        }
-
-        Err(e) => {
-            eprintln!(
-                "limabean can't run {}: {}",
-                cmd.get_program().to_string_lossy(),
-                &e
-            );
-            std::process::exit(1);
-        }
-    }
-}
-
 pub(crate) fn run(runtime: &Runtime, args: &[String]) {
     let verbose = args.iter().any(|arg| arg == "-v" || arg == "--verbose");
     let version = args.iter().any(|arg| arg == "--version");


### PR DESCRIPTION
With apologies to anyone who was using limabean on native Windows. Please switch to WSL.

Keeping things working on native Windows was simply more work than I was prepared to invest in a platform in which I have absolutely no interest.